### PR TITLE
feat: support optional filesize arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ to the humanize functions of the same name:
 
 + _humanizeFilesize_, which transforms a number or number-like string into
   a human-readable filesize such as "225.35 KB"
++ _humanizeNumberFormat_, which transforms a number or number-like string into
+  a formatted number such as "1,225.35"
 + _humanizeOrdinal_, which transforms an integer into an ordinal such as
   "32nd" or "101st"
 + _humanizeNaturalDay_, which transforms an integer representing an epoch

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,11 @@
   "main": "src/angular-humanize.js",
   "description": "Angular filter for rendering human-readable data",
   "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "*.md",
+    "package.json"
+  ],
   "dependencies": {
     "angular": "~1.2.7",
     "humanize": "~0.0.9"

--- a/src/angular-humanize.js
+++ b/src/angular-humanize.js
@@ -10,6 +10,14 @@
         return humanize.filesize.apply(null, args);
       };
     }).
+    filter('humanizeNumberFormat', function () {
+      return function () {
+        var args = Array.prototype.slice.call(arguments);
+        args[0] = parseInt(args[0])
+        if ( isNaN(args[0]) ) { return args[0]; }
+        return humanize.numberFormat.apply(null, args);
+      };
+    }).
     filter('humanizeOrdinal', function () {
       return function ( input ) {
         if ( parseInt(input) !== input ) { return input; }

--- a/src/angular-humanize.js
+++ b/src/angular-humanize.js
@@ -3,9 +3,11 @@
 
   angular.module('angular-humanize', []).
     filter('humanizeFilesize', function () {
-      return function ( input ) {
-        if ( isNaN(parseInt(input)) ) { return input; }
-        return humanize.filesize(parseInt(input));
+      return function () {
+        var args = Array.prototype.slice.call(arguments);
+        args[0] = parseInt(args[0])
+        if ( isNaN(args[0]) ) { return args[0]; }
+        return humanize.filesize.apply(null, args);
       };
     }).
     filter('humanizeOrdinal', function () {


### PR DESCRIPTION
This adds support for passing optional `humanize.filesize()` arguments with the humanizeFilesize filter.
e.g. `{{picture.bytes | humanizeFilesize : 1000 : 1 : ','}}`

See: https://github.com/taijinlee/humanize#humanizefilesizefilesize--kilo--1024-decimals--2-decpoint---thousandssep--
