### PR TITLE
Use isNaN for all number tests

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -13,8 +13,8 @@
                 },
                 {
                     name: 'joker.gif',
-                    filesize: '76160',
-                    uploaded: 1393729528
+                    filesize: '76160.3',
+                    uploaded: '1393729528.33'
                 }
              ];
          }]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/saymedia/angularjs-humanize"
   },
   "devDependencies": {
+    "grunt": "~0.4.0",
     "grunt-karma": "^0.8.2",
     "grunt-cli": "^0.1.13",
     "bower": "^1.3.1",

--- a/src/angular-humanize.js
+++ b/src/angular-humanize.js
@@ -4,25 +4,25 @@
   angular.module('angular-humanize', []).
     filter('humanizeFilesize', function () {
       return function ( input ) {
-        if ( isNaN(parseInt(input)) ) { return input; }
-        return humanize.filesize(parseInt(input));
+        if ( isNaN(input) ) { return input; }
+        return humanize.filesize(input);
       };
     }).
     filter('humanizeOrdinal', function () {
       return function ( input ) {
-        if ( parseInt(input) !== input ) { return input; }
+        if ( isNaN(input) ) { return input; }
         return humanize.ordinal(input);
       };
     }).
     filter('humanizeNaturalDay', function () {
       return function ( input ) {
-        if ( parseInt(input) !== input ) { return input; }
+        if ( isNaN(input) ) { return input; }
         return humanize.naturalDay(input);
       };
     }).
     filter('humanizeRelativeTime', function () {
       return function ( input ) {
-        if ( parseInt(input) !== input ) { return input; }
+        if ( isNaN(input) ) { return input; }
         return humanize.relativeTime(input);
       };
     });


### PR DESCRIPTION
This simplifies the code slightly, and it also allows humanise to do the
conversion to the number type it expects.

The primary reason for doing this is floats are being skipped because
they will never pass the test parseInt(input) !== input.  But as a side
effect strings that contain numbers will now also work.
